### PR TITLE
App layer

### DIFF
--- a/src/process/business_logic_interpreter.py
+++ b/src/process/business_logic_interpreter.py
@@ -1,6 +1,7 @@
 import logging
 import json
 import pandas
+import numpy as np
 
 NA_FLAG = "AUTOMATED RESPONSE UNAVAILABLE"
 IN_YES  = "Y"
@@ -12,79 +13,77 @@ AWARD_BALANCE_THRESHOLD = 0.25
 logger = logging.getLogger(__name__)
 
 def process_query_result(df):
-    
     """
     Input:  query results as a dataframe; dataframe is assumed to be a SINGLE ROW, column names refer
-            to names of columns in the database that are used to answer questions on the ERM
+            to names of columns in the database that are used to answer questions on the ERM.
         
-    Output: JSON mapping the abbreviation for each question in the form to its answer
+    Output: JSON mapping the abbreviation for each question in the form to its answer.
     """
     
-    authorized_amount = df.iloc[0,"awrd.AuthorizedAmount"]
-    billed_to_date_amt = df.iloc[0,"awrd.BilledToDateAmount"]
+    # Accessing values by column name using `.loc`
+    authorized_amount = df.loc[0, "awrd.AuthorizedAmount"]
+    billed_to_date_amt = df.loc[0, "awrd.BilledToDateAmount"]
     
-    ri1 = ri1()
+    ri1_ = ri1()
     
-    award_balance = ri2(authorized_amount, billed_to_date_amt)
+    ri2_ = ri2(authorized_amount, billed_to_date_amt)
     
-    ri3 = ri3(authorized_amount, billed_to_date_amt)
+    # needs to be converted back to numerical form to enable computations below 
+    award_balance = float(ri2_.replace("$", "")) 
     
-    # TODO: check notes and validate w/ Ed – authorized amount or total award?
-    ri4 = ri4(award_balance, authorized_amount)
+    ri3_ = ri3(authorized_amount, billed_to_date_amt)
     
-    ri5 = ri5()
+    # TODO: Check notes and validate w/ Ed – authorized amount or total award?
+    ri4_ = ri4(award_balance, authorized_amount)
     
-    ri6 = ri6()
+    ri5_ = ri5()
     
-    ri7 = ri7()
+    ri6_ = ri6()
     
-    is_human_subjects = df.iloc[0, "egc1.isHumanSubjects"]
+    ri7_ = ri7()
     
-    ri8 = ri8(is_human_subjects)
+    is_human_subjects = df.loc[0, "egc1.isHumanSubjects"]
+    ri8_ = ri8(is_human_subjects)
     
-    is_animal_use = df.iloc[0, "egc1.isAnimalUse"]
+    is_animal_use = df.loc[0, "egc1.isAnimalUse"]
+    ri9_ = ri9(is_animal_use)
     
-    ri9 = ri9(is_animal_use)
+    ri10_ = ri10()
     
-    ri10 = ri10()
+    num_prior_ext = df.loc[0, "numberPriorExtensions"]
+    ri11_ = ri11(num_prior_ext)
     
-    num_prior_ext = df.iloc[0, "numberPriorExtensions"]
+    sponsor_has_timeframe = df.loc[0, "mod.sponsorHasDeadline"]
+    sponsor_deadline_date = df.loc[0, "egc1.sponsorDeadlineDate"]
+    award_schedule_end_date = df.loc[0, "awrd.AwardScheduleEndDate"]
     
-    ri11 = ri11(num_prior_ext)
+    ri12_ = ri12(sponsor_has_timeframe, sponsor_deadline_date, award_schedule_end_date)
     
-    sponsor_has_timeframe = df.iloc[0, "mod.sponsorHasDeadline"]
-    sponsor_deadline_date = df.iloc[0, "egc1.sponsorDeadlineDate"]
-    award_schedule_end_date = df.iloc[0, "awrd.AwardScheduleEndDate"]
+    sponsor_entity_type = df.loc[0, "egc1.FECDMSponsorEntityType"]
+    project_type = df.loc[0, "egc1.projectType"]
+    ri13_ = ri13(sponsor_entity_type, project_type)
     
-    ri12 = ri12(sponsor_has_timeframe, sponsor_deadline_date, award_schedule_end_date)
+    ri14_ = ri14()
     
-    sponsor_entity_type = df.iloc[0, "egc1.FECDMSponsorEntityType"]
-    project_type = df.iloc[0, "egc1.projectType"]
-    ri13 = ri13(sponsor_entity_type, project_type)
+    ri15_ = ri15()
     
-    ri14 = ri14()
+    num_outstanding_payments = df.loc[0, "numberOutStandingPayments"]  # Corrected column name
+    ri16_ = ri16(num_outstanding_payments)
     
-    num_outstanding_payments = df.iloc[0, "numberOutstandingPayments"]
-    ri15 = ri15(num_outstanding_payments)
+    ri17_ = ri17()
     
-    ri16 = ri16()
-    
-    ri17 = ri17()
-    
-    # fill in the output JSON
-    
+    # Fill in the output JSON
     num_items = 17
     out_dict = dict()
     
     for i in range(1, num_items + 1):
         key = f"ri{i}"
-        value = locals()[key]
+        value = locals()[f"ri{i}_"]
         
         out_dict[key] = value
     
-    # return in JSON format
-    return json.dumps(out_dict)        
-
+    # Return in JSON format
+    return json.dumps(out_dict)       
 
 # helper function – translates database encoding for YES/NO to preferred output formatting
 def is_yes(db_yes_no):
@@ -96,7 +95,7 @@ def is_yes(db_yes_no):
     Output: "YES" or "NO"
     """
 
-    if isinstance(db_yes_no, str) and (db_yes_no == IN_YES | db_yes_no == IN_NO):
+    if isinstance(db_yes_no, str) and ((db_yes_no == IN_YES) | (db_yes_no == IN_NO)):
 
         if db_yes_no == IN_YES:
             return OUT_YES
@@ -105,16 +104,16 @@ def is_yes(db_yes_no):
     else:
         logger.error("Unexpected input – expected 'Y' or 'N'")
 
-
-# foramtting helper – outputs "YES" if input is TRUE (bool), "NO" otherwise
+# formatting helper – outputs "YES" if input is TRUE (bool), "NO" otherwise
 def tf_to_yn(condition):
     
-    if isinstance(condition, bool):
+    if isinstance(condition, (bool, np.bool_)):
         if condition:
             return OUT_YES
         else:
             return OUT_NO
-
+    else:
+        raise Exception(f"Expected boolean input, got {type(condition)} instead")
 
 # PLACEHOLDER: SFI current? – not possible from RAD only
 def ri1():
@@ -145,7 +144,7 @@ def ri3(authorized_amount, billed_to_date_amt):
     Input: floats representing the amounts ($) authorized and billed, respectively, for the award
     Output: "YES" if billed amt. exceeds authorized; "NO" otherwise
     """
-
+    
     return tf_to_yn((billed_to_date_amt > authorized_amount))
 
 # is the award balance greater than 25% of the total award?
@@ -228,19 +227,21 @@ def ri13(sponsor_entity_type, project_type):
 def ri14():
     return NA_FLAG
 
-# PLACEHOLDER
-def ri15(number_outstanding_payments):
+
+# PLACEHOLDER - fixed price terms?
+def ri15():
+    
+    return NA_FLAG
+
+# PLACEHOLDER - paid in full?
+def ri16(number_outstanding_payments):
     
     return tf_to_yn(
-        number_outstanding_payments > 0
+        number_outstanding_payments < 1
     )
 
 # PLACEHOLDER
 # All deliverables submitted?; not possible with RAD data alone
-def ri16():
-    
-    return NA_FLAG
-
 def ri17():
     
     return NA_FLAG

--- a/src/process/interpreter_test.ipynb
+++ b/src/process/interpreter_test.ipynb
@@ -2,26 +2,27 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "import business_logic_interpreter as bli\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "import json"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
-    "test_df_inputs = {\n",
-    "    \"awrd.AuthorizedAmount\": 100,\n",
-    "    \"awrd.BilledToDateAmount\": 75,\n",
+    "test_df_inputs1 = {\n",
+    "    \"awrd.AuthorizedAmount\": 100.0,\n",
+    "    \"awrd.BilledToDateAmount\": 77.0,\n",
     "    \"egc1.isHumanSubjects\": \"Y\",\n",
     "    \"egc1.isAnimalUse\": \"N\",\n",
-    "    \"numberPriorExtensions\": 2,\n",
+    "    \"numberPriorExtensions\": 0,\n",
     "    \"numberOutStandingPayments\": 0,\n",
     "    \"mod.sponsorHasDeadline\": \"Y\",\n",
     "    \"egc1.sponsorDeadlineDate\": \"2025-03-30\",\n",
@@ -33,62 +34,161 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   awrd.AuthorizedAmount  awrd.BilledToDateAmount egc1.isHumanSubjects  \\\n",
-      "0                    100                       75                    Y   \n",
-      "\n",
-      "  egc1.isAnimalUse  numberPriorExtensions  numberOutStandingPayments  \\\n",
-      "0                N                      2                          0   \n",
-      "\n",
-      "  mod.sponsorHasDeadline egc1.sponsorDeadlineDate awrd.AwardScheduleEndDate  \\\n",
-      "0                      Y               2025-03-30                2025-04-15   \n",
-      "\n",
-      "  egc1.FECDMSponsorEntityType egc1.projectType  \n",
-      "0          Federal Government         Contract  \n"
-     ]
+     "data": {
+      "text/plain": [
+       "{'ri1': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri2': '$23.00',\n",
+       " 'ri3': 'NO',\n",
+       " 'ri4': 'NO',\n",
+       " 'ri5': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri6': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri7': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri8': 'YES',\n",
+       " 'ri9': 'NO',\n",
+       " 'ri10': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri11': 'NO',\n",
+       " 'ri12': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri13': 'YES',\n",
+       " 'ri14': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri15': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri16': 'YES',\n",
+       " 'ri17': 'AUTOMATED RESPONSE UNAVAILABLE'}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "# Create a DataFrame with a single row\n",
-    "df = pd.DataFrame([test_df_inputs])\n",
+    "df1 = pd.DataFrame([test_df_inputs1])\n",
     "\n",
-    "print(df)"
+    "json.loads(bli.process_query_result(df1))\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_df_inputs2 = {\n",
+    "    \"awrd.AuthorizedAmount\": 100.0,\n",
+    "    \"awrd.BilledToDateAmount\": 74.0,\n",
+    "    \"egc1.isHumanSubjects\": \"N\",\n",
+    "    \"egc1.isAnimalUse\": \"Y\",\n",
+    "    \"numberPriorExtensions\": 1,\n",
+    "    \"numberOutStandingPayments\": 1,\n",
+    "    \"mod.sponsorHasDeadline\": \"Y\",\n",
+    "    \"egc1.sponsorDeadlineDate\": \"2025-03-30\",\n",
+    "    \"awrd.AwardScheduleEndDate\": \"2025-04-15\",\n",
+    "    \"egc1.FECDMSponsorEntityType\": \"Federal Government\",\n",
+    "    \"egc1.projectType\": \"Grant\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
-     "ename": "ValueError",
-     "evalue": "Location based indexing can only have [integer, integer slice (START point is INCLUDED, END point is EXCLUDED), listlike of integers, boolean array] types",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "File \u001b[0;32m~/Library/Python/3.12/lib/python/site-packages/pandas/core/indexing.py:966\u001b[0m, in \u001b[0;36m_LocationIndexer._validate_tuple_indexer\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m    965\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m--> 966\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_validate_key\u001b[49m\u001b[43m(\u001b[49m\u001b[43mk\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mi\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    967\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n",
-      "File \u001b[0;32m~/Library/Python/3.12/lib/python/site-packages/pandas/core/indexing.py:1614\u001b[0m, in \u001b[0;36m_iLocIndexer._validate_key\u001b[0;34m(self, key, axis)\u001b[0m\n\u001b[1;32m   1613\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m-> 1614\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mCan only index by location with a [\u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_valid_types\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m]\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
-      "\u001b[0;31mValueError\u001b[0m: Can only index by location with a [integer, integer slice (START point is INCLUDED, END point is EXCLUDED), listlike of integers, boolean array]",
-      "\nThe above exception was the direct cause of the following exception:\n",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[10], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mbli\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mprocess_query_result\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdf\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/Documents/uw/capstone/osp-nce/src/process/business_logic_interpreter.py:23\u001b[0m, in \u001b[0;36mprocess_query_result\u001b[0;34m(df)\u001b[0m\n\u001b[1;32m     14\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mprocess_query_result\u001b[39m(df):\n\u001b[1;32m     16\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m     17\u001b[0m \u001b[38;5;124;03m    Input:  query results as a dataframe; dataframe is assumed to be a SINGLE ROW, column names refer\u001b[39;00m\n\u001b[1;32m     18\u001b[0m \u001b[38;5;124;03m            to names of columns in the database that are used to answer questions on the ERM\u001b[39;00m\n\u001b[1;32m     19\u001b[0m \u001b[38;5;124;03m        \u001b[39;00m\n\u001b[1;32m     20\u001b[0m \u001b[38;5;124;03m    Output: JSON mapping the abbreviation for each question in the form to its answer\u001b[39;00m\n\u001b[1;32m     21\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m---> 23\u001b[0m     authorized_amount \u001b[38;5;241m=\u001b[39m \u001b[43mdf\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43miloc\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m,\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mawrd.AuthorizedAmount\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\n\u001b[1;32m     24\u001b[0m     billed_to_date_amt \u001b[38;5;241m=\u001b[39m df\u001b[38;5;241m.\u001b[39miloc[\u001b[38;5;241m0\u001b[39m,\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mawrd.BilledToDateAmount\u001b[39m\u001b[38;5;124m\"\u001b[39m]\n\u001b[1;32m     26\u001b[0m     ri1 \u001b[38;5;241m=\u001b[39m ri1()\n",
-      "File \u001b[0;32m~/Library/Python/3.12/lib/python/site-packages/pandas/core/indexing.py:1184\u001b[0m, in \u001b[0;36m_LocationIndexer.__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   1182\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_is_scalar_access(key):\n\u001b[1;32m   1183\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mobj\u001b[38;5;241m.\u001b[39m_get_value(\u001b[38;5;241m*\u001b[39mkey, takeable\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_takeable)\n\u001b[0;32m-> 1184\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_getitem_tuple\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1185\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m   1186\u001b[0m     \u001b[38;5;66;03m# we by definition only have the 0th axis\u001b[39;00m\n\u001b[1;32m   1187\u001b[0m     axis \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39maxis \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;241m0\u001b[39m\n",
-      "File \u001b[0;32m~/Library/Python/3.12/lib/python/site-packages/pandas/core/indexing.py:1690\u001b[0m, in \u001b[0;36m_iLocIndexer._getitem_tuple\u001b[0;34m(self, tup)\u001b[0m\n\u001b[1;32m   1689\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_getitem_tuple\u001b[39m(\u001b[38;5;28mself\u001b[39m, tup: \u001b[38;5;28mtuple\u001b[39m):\n\u001b[0;32m-> 1690\u001b[0m     tup \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_validate_tuple_indexer\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtup\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1691\u001b[0m     \u001b[38;5;28;01mwith\u001b[39;00m suppress(IndexingError):\n\u001b[1;32m   1692\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_getitem_lowerdim(tup)\n",
-      "File \u001b[0;32m~/Library/Python/3.12/lib/python/site-packages/pandas/core/indexing.py:968\u001b[0m, in \u001b[0;36m_LocationIndexer._validate_tuple_indexer\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m    966\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_validate_key(k, i)\n\u001b[1;32m    967\u001b[0m     \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n\u001b[0;32m--> 968\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\n\u001b[1;32m    969\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mLocation based indexing can only have \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    970\u001b[0m             \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m[\u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_valid_types\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m] types\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    971\u001b[0m         ) \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01merr\u001b[39;00m\n\u001b[1;32m    972\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m key\n",
-      "\u001b[0;31mValueError\u001b[0m: Location based indexing can only have [integer, integer slice (START point is INCLUDED, END point is EXCLUDED), listlike of integers, boolean array] types"
-     ]
+     "data": {
+      "text/plain": [
+       "{'ri1': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri2': '$26.00',\n",
+       " 'ri3': 'NO',\n",
+       " 'ri4': 'YES',\n",
+       " 'ri5': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri6': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri7': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri8': 'NO',\n",
+       " 'ri9': 'YES',\n",
+       " 'ri10': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri11': 'NO',\n",
+       " 'ri12': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri13': 'NO',\n",
+       " 'ri14': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri15': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri16': 'NO',\n",
+       " 'ri17': 'AUTOMATED RESPONSE UNAVAILABLE'}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "bli.process_query_result(df)"
+    "# Create a DataFrame with a single row\n",
+    "df2 = pd.DataFrame([test_df_inputs2])\n",
+    "\n",
+    "json.loads(bli.process_query_result(df2))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_df_inputs3 = {\n",
+    "    \"awrd.AuthorizedAmount\": 100.0,\n",
+    "    \"awrd.BilledToDateAmount\": 103.0,\n",
+    "    \"egc1.isHumanSubjects\": \"N\",\n",
+    "    \"egc1.isAnimalUse\": \"Y\",\n",
+    "    \"numberPriorExtensions\": 1,\n",
+    "    \"numberOutStandingPayments\": 1,\n",
+    "    \"mod.sponsorHasDeadline\": \"Y\",\n",
+    "    \"egc1.sponsorDeadlineDate\": \"2025-03-30\",\n",
+    "    \"awrd.AwardScheduleEndDate\": \"2025-04-15\",\n",
+    "    \"egc1.FECDMSponsorEntityType\": \"Industry\",\n",
+    "    \"egc1.projectType\": \"Grant\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'ri1': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri2': '$-3.00',\n",
+       " 'ri3': 'YES',\n",
+       " 'ri4': 'NO',\n",
+       " 'ri5': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri6': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri7': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri8': 'NO',\n",
+       " 'ri9': 'YES',\n",
+       " 'ri10': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri11': 'NO',\n",
+       " 'ri12': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri13': 'NO',\n",
+       " 'ri14': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri15': 'AUTOMATED RESPONSE UNAVAILABLE',\n",
+       " 'ri16': 'NO',\n",
+       " 'ri17': 'AUTOMATED RESPONSE UNAVAILABLE'}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Create a DataFrame with a single row\n",
+    "df3 = pd.DataFrame([test_df_inputs3])\n",
+    "\n",
+    "json.loads(bli.process_query_result(df3))\n"
    ]
   }
  ],


### PR DESCRIPTION
This PR:
- Addresses bugs in the initial `src/business_logic_interpreter.py`
- Adds a notebook (`src/interpreter_test.ipynb`) documenting tests of `src/business_logic_interpreter.py`. This also shows how the frontend should call the public method in the application layer. @SidGurajala this is probably most relevant for frontend development.

Remaining to-dos:
- Add support for for `ri12` – "is the request within the sponsor's timeframe?". As of this PR, processing this question is still not supported as we need to clarify business logic nuances.